### PR TITLE
Fix crash

### DIFF
--- a/viewpageranimator/src/main/java/com/stylingandroid/viewpageranimator/ViewPagerAnimator.java
+++ b/viewpageranimator/src/main/java/com/stylingandroid/viewpageranimator/ViewPagerAnimator.java
@@ -124,7 +124,7 @@ public class ViewPagerAnimator<V> implements ViewPager.OnPageChangeListener {
 
     private void beginAnimation(int position) {
         PagerAdapter adapter = viewPager.getAdapter();
-        if (position == currentPage && position + 1 <= adapter.getCount()) {
+        if (position == currentPage && position + 1 < adapter.getCount()) {
             targetPage = position + 1;
             startValue = provider.get(position);
             endValue = provider.get(targetPage);


### PR DESCRIPTION
I think that this is a bug, right?
If you have positions 0-6,  it means that adapter.getCount == 7
So if your current page is 6 (last tab) and targetPage is set to 7 (position + 1) you may ask for position which is not available.
